### PR TITLE
[fix]宣言達成チェックの修正

### DIFF
--- a/resources/views/achievement/card.blade.php
+++ b/resources/views/achievement/card.blade.php
@@ -76,9 +76,6 @@
     @endforeach
 
     <div class="card-body line-height">
-        <div id="comment-article-{{ $article->id }}">
-            @include('articles.comment_list')
-        </div>
         {{ $article->created_at }}
     </div>
 


### PR DESCRIPTION
### 宣言達成チェックの修正
- 達成チェック画面に遷移時、存在しないファイル名の記述が原因で404エラーが発生していたのを修正した